### PR TITLE
Fix missing double quotes shell variables

### DIFF
--- a/bashhub/shell/bashhub.sh
+++ b/bashhub/shell/bashhub.sh
@@ -23,14 +23,14 @@ __bh_setup_bashhub() {
        [[ -f $BH_DEPS_DIRECTORY/bash-preexec.sh ]]; then
 
         # Pull in our libs
-        source $BH_DEPS_DIRECTORY/lib-bashhub.sh
-        source $BH_DEPS_DIRECTORY/bash-preexec.sh
+        source "$BH_DEPS_DIRECTORY/lib-bashhub.sh"
+        source "$BH_DEPS_DIRECTORY/bash-preexec.sh"
 
         # Hook bashhub into preexec and precmd.
         __bh_hook_bashhub
 
         # Install our tab completion
-        source $BH_DEPS_DIRECTORY/bashhub_completion_handler.sh
+        source "$BH_DEPS_DIRECTORY/bashhub_completion_handler.sh"
     fi
 }
 
@@ -52,8 +52,8 @@ __bh_hook_bashhub() {
 
 __bh_bash_precmd() {
     if [[ -e $BH_HOME_DIRECTORY/response.bh ]]; then
-        local command=$(head -n 1 $BH_HOME_DIRECTORY/response.bh)
-        rm $BH_HOME_DIRECTORY/response.bh
+        local command=$(head -n 1 "$BH_HOME_DIRECTORY/response.bh")
+        rm "$BH_HOME_DIRECTORY/response.bh"
         history -s "$command"
         echo "$command"
         eval "$command"


### PR DESCRIPTION
Missing double quotes shell variable in scalar context can lead to many security implication.

In `bashhub.sh`, bashhub got the `BH_DEPS_DIRECTORY` from shell environment:
```
BH_DEPS_DIRECTORY=${BH_DEPS_DIRECTORY:=$BH_HOME_DIRECTORY/deps}
```

Then many places use it without double quote. At least it made the user can not use directory with space in name as `BH_DEPS_DIRECTORY`.

A more dangerous example:
```
$ cp -r .bashhub/deps /tmp/'dir with space'
$ echo 'echo QWERT' > /tmp/dir
```
Now if user set:
```
export BH_DEPS_DIRECTORY=/tmp/dir\ with\ space/
### Bashhub.com Installation.
### This Should be at the EOF. https://bashhub.com/docs
if [ -f ~/.bashhub/bashhub.sh ]; then
    source ~/.bashhub/bashhub.sh
fi
```

Anyone in system can made the user `source` the file they want by creating file named `/tmp/dir`.