### PR TITLE
Fix bash array reference syntax

### DIFF
--- a/bashhub/shell/bashhub.sh
+++ b/bashhub/shell/bashhub.sh
@@ -40,11 +40,11 @@ __bh_hook_bashhub() {
     bind '"\C-b":"\C-u\C-kbh -i\n"'
 
     # Hook into preexec and precmd functions
-    if ! contains_element __bh_preexec $preexec_functions; then
+    if ! contains_element __bh_preexec "${preexec_functions[@]}"; then
         preexec_functions+=(__bh_preexec)
     fi
 
-    if ! contains_element __bh_precmd $precmd_functions; then
+    if ! contains_element __bh_precmd "${preexec_functions[@]}"; then
         precmd_functions+=(__bh_precmd)
         precmd_functions+=(__bh_bash_precmd)
     fi


### PR DESCRIPTION
Using `$array` to get all array elements is the `zsh` syntax, in `bash` we need `${array[@]}` since when reference array without subscript is equivalent with a subscript `0`:
```
array=(1 2 3)
echo "$array"
echo "${array[0]}"
```
all gave `1`.