### PR TITLE
Default to using hostname as string for mac

### DIFF
--- a/bashhub/bashhub_setup.py
+++ b/bashhub/bashhub_setup.py
@@ -107,7 +107,7 @@ def get_mac_address():
     if (mac >> 40) & 1:
         hostname = socket.gethostname()
         print("warning: cannot find MAC. Using hostname (%s) to identify system" % hostname)
-        mac = str(abs(hash(hostname)))
+        mac = hostname
     else:
         mac = str(mac)
     return mac

--- a/tests/test_bashhub_setup.py
+++ b/tests/test_bashhub_setup.py
@@ -31,7 +31,7 @@ class BashhubSetupTest(unittest.TestCase):
 		# with uuid returning random
 		uuid.getnode = randomnode
 		hostname_mac = bashhub_setup.get_mac_address()
-		assert str(abs(hash(socket.gethostname()))) == hostname_mac
+		assert socket.gethostname() == hostname_mac
 
 	@patch('bashhub.bashhub_setup.rest_client')
 	@patch('bashhub.bashhub_setup.input', side_effect=['sys1', 'sys2', "sys3", "sys4"])


### PR DESCRIPTION
- hash(..) was returning inconsistent results on some VMs. Default to
  just using the hostname as a string for now since there's no
  requirement it's a number.
- originally fixed on issue #82