### PR TITLE
Patch install script for python 3.12

### DIFF
--- a/install-bashhub.sh
+++ b/install-bashhub.sh
@@ -38,9 +38,16 @@ fi
 
 PYTHON_VERSION_COMMAND='
 import sys
-if (3, 6, 0) < sys.version_info < (3, 12, 0):
+if (3, 6, 0) < sys.version_info < (3, 13, 0):
   sys.exit(0)
 elif (2, 7, 8) < sys.version_info < (3,0):
+  sys.exit(0)
+else:
+  sys.exit(-1)'
+
+IS_PYTHON_VERSION_312='
+import sys
+if sys.version_info >= (3, 12, 0):
   sys.exit(0)
 else:
   sys.exit(-1)'
@@ -264,6 +271,15 @@ setup_bashhub_files() {
 
     # install our packages. bashhub and dependencies.
     echo "Pulling down a few dependencies...(this may take a moment)"
+    # Note: This is a hack to get bashhub working for python 3.12
+    if "python" -c "$IS_PYTHON_VERSION_312"; then
+        # upgrade pip
+        ../env/bin/python -m ensurepip --upgrade
+        ../env/bin/python -m pip install --upgrade setuptools pip
+        # Set requests to 2.32 for python 3.12
+        sed -i 's/requests==2.23.0/requests==2.32/' setup.py
+    fi
+    # Now install the remaining dependencies
     ../env/bin/pip -qq install .
 
     # Check if we already have a config. If not run setup.


### PR DESCRIPTION
bashhub currently works only for python 3.11 and below.

There are couple of issues with python 3.12 with bashhub, both requires just the updated package versions for pip and requests.

This PR modifies requests version to 2.32 (in setup.py) only for python 3.12.  This is only if the latest requests, as of now, 2.32 breaks for older versions of python, which I am not sure.