### PR TITLE
Support Python 3.13 in installer

### DIFF
--- a/install-bashhub.sh
+++ b/install-bashhub.sh
@@ -38,7 +38,7 @@ fi
 
 PYTHON_VERSION_COMMAND='
 import sys
-if (3, 6, 0) < sys.version_info < (3, 12, 0):
+if (3, 6, 0) < sys.version_info < (3, 14, 0):
   sys.exit(0)
 elif (2, 7, 8) < sys.version_info < (3,0):
   sys.exit(0)
@@ -49,6 +49,8 @@ else:
 PYTHON_VERSION_ARRAY=(
     "/usr/bin/python3"
     "python3"
+    "python3.13"
+    "python3.12"
     "python3.11"
     "python3.10"
     "python3.9"
@@ -95,7 +97,7 @@ get_and_check_python_version() {
 download_and_install_env() {
     local python_command=$(get_and_check_python_version)
     if [[ -z "$python_command" ]]; then
-        die "\n Sorry you need to have python 3.6-3.11 or 2.7.9+ installed. Please install it and rerun this script." 1
+        die "\n Sorry you need to have python 3.6-3.13 or 2.7.9+ installed. Please install it and rerun this script." 1
     fi
 
     # Set to whatever python interpreter you want for your first environment
@@ -114,7 +116,7 @@ download_and_install_env() {
 
 check_dependencies() {
     if [ -z "$(get_and_check_python_version)" ]; then
-        die "\n Sorry can't seem to find a version of python 3.6-3.11 or 2.7.9+ installed" 1
+        die "\n Sorry can't seem to find a version of python 3.6-3.13 or 2.7.9+ installed" 1
     fi
 
     if [ -z "$(detect_shell_type)" ]; then

--- a/tests/shell/install-bashhub.bats
+++ b/tests/shell/install-bashhub.bats
@@ -29,21 +29,23 @@ setup() {
   [[ $status == 0 ]]
 }
 
-@test "get_and_check_python_version should find python3.11 first" {
+@test "get_and_check_python_version should find python3.13 first" {
   # Mock up some fake responses here.
   /usr/bin/python3() { return 1; }
   python3() { return 1; }
-  python3.11() { return 0; }
+  python3.13() { return 0; }
 
   run 'get_and_check_python_version'
   [[ $status == 0 ]]
-  [[ "$output" == "python3.11" ]]
+  [[ "$output" == "python3.13" ]]
 }
 
 @test "get_and_check_python_version should find different python versions" {
   # Mock up some fake responses here.
   /usr/bin/python3() { return 1; }
   python3() { return 1; }
+  python3.13() { return 1; }
+  python3.12() { return 1; }
   python3.11() { return 1; }
   python3.10() { return 1; }
   python3.9() { return 1; }


### PR DESCRIPTION
## Summary
- add python3.13 support in install script
- update bats tests to expect python3.13

## Testing
- `pytest -q`
- `bats tests/shell`


------
https://chatgpt.com/codex/tasks/task_e_6847854611b8832eb561e8ef31c91584